### PR TITLE
Return error in /wiki command when status code is not 200

### DIFF
--- a/bot_cmd_wiki.go
+++ b/bot_cmd_wiki.go
@@ -20,7 +20,9 @@ func commandWiki(cm CommandManager, args string, message discordgo.Message, cont
 	response, _ := http.Get(wikiURL)
 	bodyText, _ := ioutil.ReadAll(response.Body)
 
-	if strings.Contains(string(bodyText), "There is currently no text in this page, you can") {
+	if response.StatusCode != 200 {
+		cm.App.discordClient.ChannelMessageSend(message.ChannelID, "Could not retrieve SA:MP wiki article:\nGot unexpected response: "+response.Status+".")
+	} else if strings.Contains(string(bodyText), "There is currently no text in this page, you can") {
 		cm.App.discordClient.ChannelMessageSend(message.ChannelID, "SA:MP Wiki | "+args+"\n- This article does not exist")
 	} else {
 		cm.App.discordClient.ChannelMessageSend(message.ChannelID, "SA:MP Wiki | "+args+"\n"+wikiURL)


### PR DESCRIPTION
The wiki (and the forums too) has been returning errors more often these days, confusing CJ when he tries to find an article: because `"There is currently no text in this page, you can"` is not present, CJ thinks it's valid, giving results like this:

![imagen](https://user-images.githubusercontent.com/18301034/44622342-dec88e80-a8b6-11e8-8231-937f108a01e4.png)

Fortunately the Wiki error message comes with a 500 response code. This PR checks if the response is `200 OK` before parsing the response, otherwise gives an error.