### PR TITLE
Change 💾 to 🔒 in /stats password field

### DIFF
--- a/bot/commands/cmd_stats.go
+++ b/bot/commands/cmd_stats.go
@@ -99,7 +99,7 @@ func (cm *CommandManager) commandStats(
 				Inline: true,
 			},
 			&discordgo.MessageEmbedField{
-				Name:   "💾 Password",
+				Name:   "🔒 Password",
 				Value:  password,
 				Inline: true,
 			},


### PR DESCRIPTION
Why was it a 💾?