### PR TITLE
Remove obsolete line from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,9 +8,6 @@
 
 CJ verifies Burgershot (formerly SA:MP) forum accounts and performs other tasks if you ask nicely.
 
-Not really in development and not accepting new features. I fix bugs from time to time but it serves it purpose as a
-verification tool and basic forum interface.
-
 ## Development
 
 This project is open to anyone who wants to contribute, large or small! Whether you noticed a typo or want to add a


### PR DESCRIPTION
The extra change is because of mixed up line endings that I can't fix on the github page
![image](https://user-images.githubusercontent.com/15870306/81502569-0e176d00-92df-11ea-9c1b-ed6710c261e0.png)
