### PR TITLE
Fix inaccessible random option in gmname command

### DIFF
--- a/bot/commands/cmd_gmname.go
+++ b/bot/commands/cmd_gmname.go
@@ -186,7 +186,7 @@ func generateGmName() (result string) {
 		buf.WriteString(strings.ToTitle(gamemodes))
 	case 2:
 		buf.WriteString(strings.ToUpper(gamemodes))
-	case 4:
+	case 3:
 		buf.WriteString("[" + strings.ToUpper(gamemodes) + "]")
 	}
 


### PR DESCRIPTION
One of the cases is not linked to a valid return value of rand.Intn(4) which is [0,3]. Now we missed the `PISD PISD [PISD]` server :(

![image](https://user-images.githubusercontent.com/15870306/82154570-13406300-986f-11ea-829f-2fab8143fd9e.png)
