### PR TITLE
remove initialisation message from bot startup

### DIFF
--- a/bot/core.go
+++ b/bot/core.go
@@ -1,7 +1,6 @@
 package bot
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"

--- a/bot/core.go
+++ b/bot/core.go
@@ -85,13 +85,6 @@ func Start(config *types.Config) {
 		}
 	}
 
-	_, err = app.discordClient.S.ChannelMessageSend(
-		config.DefaultChannel,
-		fmt.Sprintf("Hey, what's cracking now? CJ initialised with version %s", config.Version))
-	if err != nil {
-		zap.L().Fatal("failed to send initialisation message", zap.Error(err))
-	}
-
 	zap.L().Debug("started with debug logging enabled",
 		zap.Int("extensions", len(app.extensions)),
 		zap.Any("config", config))


### PR DESCRIPTION
the:
"Hey, what's cracking now? CJ initialised with version
Hey, what's cracking now? CJ initialised with version
Hey, what's cracking now? CJ initialised with version
Hey, what's cracking now? CJ initialised with version
Hey, what's cracking now? CJ initialised with version"

is no more.