### PR TITLE
Truncate long wiki descriptions

### DIFF
--- a/bot/commands/cmd_wiki.go
+++ b/bot/commands/cmd_wiki.go
@@ -26,6 +26,13 @@ const (
 	algoliaInsights         = false
 )
 
+func truncateText(s string, max int) string {
+	if max > len(s) {
+		return s
+	}
+	return s[:strings.LastIndex(s[:max], " ")] + " ..."
+}
+
 func (cm *CommandManager) commandWiki(
 	interaction *discordgo.InteractionCreate,
 	args map[string]*discordgo.ApplicationCommandInteractionDataOption,
@@ -123,7 +130,7 @@ func (cm *CommandManager) commandWiki(
 			hitData["url_without_anchor"].(string),
 			stringParts[len(stringParts)-3],
 			stringParts[len(stringParts)-2],
-			description,
+			truncateText(description, 200),
 		))
 	}
 


### PR DESCRIPTION
The current implementation for wiki search does not exactly pull the wiki description, more like what the scraper decided was the content.

This change truncates long responses, avoiding stuff like 
![image](https://github.com/user-attachments/assets/50a99989-fd53-4d78-9cf2-d4af7ffc387b)

